### PR TITLE
[FEAT] 달력&일기 조회 구현

### DIFF
--- a/src/main/java/com/example/sketchTalk/controller/DiaryController.java
+++ b/src/main/java/com/example/sketchTalk/controller/DiaryController.java
@@ -3,12 +3,14 @@ package com.example.sketchTalk.controller;
 import com.example.sketchTalk._core.common.ApiResponse;
 import com.example.sketchTalk.dto.diary.in.ModifyDiaryReq;
 import com.example.sketchTalk.dto.diary.in.SaveDiaryReq;
-import com.example.sketchTalk.dto.diary.out.ModifyDiaryRes;
-import com.example.sketchTalk.dto.diary.out.SaveDiaryRes;
+import com.example.sketchTalk.dto.diary.out.*;
 import com.example.sketchTalk.service.DiaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/diary")
@@ -26,5 +28,37 @@ public class DiaryController {
     public ApiResponse<ModifyDiaryRes> modifyDiary(@RequestBody ModifyDiaryReq req) {
         ModifyDiaryRes modifyDiaryRes = diaryService.changeDiary(req);
         return ApiResponse.onSuccess(HttpStatus.OK, modifyDiaryRes);
+    }
+
+    @GetMapping("/cal")
+    public ApiResponse<List<GetCalanderDiraryRes>> getCalander(
+            @RequestParam int year,
+            @RequestParam int month,
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<GetCalanderDiraryRes> getCalanderDiraryRes = diaryService.getCalanderByMonth(year, month, userId);
+        return ApiResponse.onSuccess(HttpStatus.OK, getCalanderDiraryRes);
+    }
+
+    @GetMapping("/list")
+    public ApiResponse<List<GetDiaryPreviewRes>> getList(
+            @RequestParam int year,
+            @RequestParam int month,
+            @AuthenticationPrincipal Long userId
+    ) {
+        List<GetDiaryPreviewRes> getDiaryListRes = diaryService.getDiaryListByMonth(year, month, userId);
+        return ApiResponse.onSuccess(HttpStatus.OK, getDiaryListRes);
+    }
+
+    @GetMapping("/{id}/preview")
+    public ApiResponse<GetDiaryPreviewRes> getDiaryPreview(@PathVariable Long id, @AuthenticationPrincipal Long userId) {
+        GetDiaryPreviewRes getDiaryPreviewRes = diaryService.getDiaryPreviewById(id, userId);
+        return ApiResponse.onSuccess(HttpStatus.OK, getDiaryPreviewRes);
+    }
+
+    @GetMapping("/{id}")
+    public ApiResponse<GetDiaryDetailRes> getDiaryDetail(@PathVariable Long id, @AuthenticationPrincipal Long userId) {
+        GetDiaryDetailRes getDiaryDetailRes = diaryService.getDiaryDetailById(id, userId);
+        return ApiResponse.onSuccess(HttpStatus.OK, getDiaryDetailRes);
     }
 }

--- a/src/main/java/com/example/sketchTalk/dto/diary/out/GetCalanderDiraryRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/diary/out/GetCalanderDiraryRes.java
@@ -1,0 +1,11 @@
+package com.example.sketchTalk.dto.diary.out;
+
+import com.example.sketchTalk.model.Emotion;
+
+import java.time.LocalDate;
+
+public record GetCalanderDiraryRes(
+        Long diaryId,
+        LocalDate date,
+        Emotion emotion
+) {}

--- a/src/main/java/com/example/sketchTalk/dto/diary/out/GetDiaryDetailRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/diary/out/GetDiaryDetailRes.java
@@ -1,0 +1,16 @@
+package com.example.sketchTalk.dto.diary.out;
+
+import com.example.sketchTalk.model.Emotion;
+
+import java.time.LocalDate;
+
+public record GetDiaryDetailRes(
+        Long diaryId,
+        LocalDate date,
+        Emotion emotion,
+        String title,
+        String content,
+        String imageUrl,
+        String comment
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/diary/out/GetDiaryPreviewRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/diary/out/GetDiaryPreviewRes.java
@@ -1,0 +1,14 @@
+package com.example.sketchTalk.dto.diary.out;
+
+import com.example.sketchTalk.model.Emotion;
+
+import java.time.LocalDate;
+
+public record GetDiaryPreviewRes(
+        Long diaryId,
+        LocalDate date,
+        Emotion emotion,
+        String title,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/example/sketchTalk/model/Style.java
+++ b/src/main/java/com/example/sketchTalk/model/Style.java
@@ -1,0 +1,5 @@
+package com.example.sketchTalk.model;
+
+public enum Style {
+    Temp
+}

--- a/src/main/java/com/example/sketchTalk/model/entity/Comment.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Comment.java
@@ -14,14 +14,15 @@ public class Comment {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-    @Column(name="diary_id")
-    private Long diaryId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
 
     @Column(name="content")
     private String content;
 
-    public Comment(Long diaryId, String content) {
-        this.diaryId = diaryId;
+    public Comment(Diary diary, String content) {
+        this.diary = diary;
         this.content = content;
     }
 }

--- a/src/main/java/com/example/sketchTalk/model/entity/Diary.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Diary.java
@@ -10,7 +10,9 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Getter
@@ -42,6 +44,11 @@ public class Diary {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
+    private Image image;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
+    private Comment comment;
 
     public Diary(SaveDiaryReq saveDiaryReq) {
         this.userId = saveDiaryReq.userId();//추후에 User로 변경

--- a/src/main/java/com/example/sketchTalk/model/entity/Image.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Image.java
@@ -1,0 +1,29 @@
+package com.example.sketchTalk.model.entity;
+
+import com.example.sketchTalk.model.Style;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "image")
+public class Image {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="image_id")
+    private Long imageId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Style style;
+
+    @Column(nullable = false)
+    private String url;
+}

--- a/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
+++ b/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
@@ -1,7 +1,17 @@
 package com.example.sketchTalk.repository;
 
+import com.example.sketchTalk.dto.diary.out.GetCalanderDiraryRes;
 import com.example.sketchTalk.model.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<GetCalanderDiraryRes> findAllByUserIdAndDateBetween(Long userId, LocalDate dateAfter, LocalDate dateBefore);
+    List<Diary> findAllByUserIdAndDateBetweenOrderByDateAsc(Long userId, LocalDate start, LocalDate end);
+
+    Optional<Diary> findByUserIdAndDiaryId(Long userId, Long diaryId);
 }

--- a/src/main/java/com/example/sketchTalk/service/CommentService.java
+++ b/src/main/java/com/example/sketchTalk/service/CommentService.java
@@ -1,10 +1,14 @@
 package com.example.sketchTalk.service;
 
+import com.example.sketchTalk._core.error.CustomException;
 import com.example.sketchTalk.dto.comment.in.SaveCommentReq;
 import com.example.sketchTalk.dto.comment.out.ReqContentRes;
 import com.example.sketchTalk.dto.comment.out.SaveCommentRes;
+import com.example.sketchTalk.exception.diary.DiaryExceptions;
 import com.example.sketchTalk.model.entity.Comment;
+import com.example.sketchTalk.model.entity.Diary;
 import com.example.sketchTalk.repository.CommentRepository;
+import com.example.sketchTalk.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,9 +16,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
+    private final DiaryRepository diaryRepository;
 
     public SaveCommentRes putComment(SaveCommentReq saveCommentReq) {
-        Comment comment = new Comment(saveCommentReq.diaryId(), saveCommentReq.content());
+        Diary diary = diaryRepository.findById(saveCommentReq.diaryId()).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND));
+
+        Comment comment = new Comment(diary, saveCommentReq.content());
         Comment savedComment = commentRepository.save(comment);
         return new SaveCommentRes(savedComment.getCommentId(), savedComment.getContent());
     }

--- a/src/main/java/com/example/sketchTalk/service/DiaryService.java
+++ b/src/main/java/com/example/sketchTalk/service/DiaryService.java
@@ -1,20 +1,18 @@
 package com.example.sketchTalk.service;
 
 import com.example.sketchTalk._core.error.CustomException;
-import com.example.sketchTalk.dto.comment.in.SaveCommentReq;
-import com.example.sketchTalk.dto.comment.out.ReqContentRes;
-import com.example.sketchTalk.dto.comment.out.SaveCommentRes;
 import com.example.sketchTalk.dto.diary.in.ModifyDiaryReq;
 import com.example.sketchTalk.dto.diary.in.SaveDiaryReq;
-import com.example.sketchTalk.dto.diary.out.ModifyDiaryRes;
-import com.example.sketchTalk.dto.diary.out.SaveDiaryRes;
+import com.example.sketchTalk.dto.diary.out.*;
 import com.example.sketchTalk.exception.diary.DiaryExceptions;
 import com.example.sketchTalk.model.entity.Diary;
 import com.example.sketchTalk.repository.DiaryRepository;
+import com.example.sketchTalk.security.jwt.JwtUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.util.List;
 
 
@@ -22,6 +20,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryRepository diaryRepository;
+    private final JwtUtils jwtUtils;
 //    private final CommentService commentService;
 
     public SaveDiaryRes putDiary(SaveDiaryReq saveDiaryReq) {
@@ -78,5 +77,60 @@ public class DiaryService {
 
     private void updateAchievement() {
 
+    }
+
+    public List<GetCalanderDiraryRes> getCalanderByMonth(int year, int month, Long userId) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        return diaryRepository.findAllByUserIdAndDateBetween(userId, start, end);
+    }
+
+    public List<GetDiaryPreviewRes> getDiaryListByMonth(int year, int month, Long userId) {
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        return diaryRepository.findAllByUserIdAndDateBetweenOrderByDateAsc(userId, start, end)
+                .stream()
+                .map(d -> {
+                    String imageUrl = d.getImage() != null ? d.getImage().getUrl() : null;
+                    return new GetDiaryPreviewRes(
+                            d.getDiaryId(),
+                            d.getDate(),
+                            d.getEmotion(),
+                            d.getTitle(),
+                            imageUrl
+                    );
+                })
+                .toList();
+    }
+
+    public GetDiaryPreviewRes getDiaryPreviewById(Long id, Long userId) {
+        Diary diary = diaryRepository.findByUserIdAndDiaryId(userId, id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
+
+        String imageUrl = diary.getImage() != null ? diary.getImage().getUrl() : null;
+        return new GetDiaryPreviewRes(
+                diary.getDiaryId(),
+                diary.getDate(),
+                diary.getEmotion(),
+                diary.getTitle(),
+                imageUrl
+        );
+    }
+
+    public GetDiaryDetailRes getDiaryDetailById(Long id, Long userId) {
+        Diary diary = diaryRepository.findByUserIdAndDiaryId(userId, id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
+
+        String imageUrl = diary.getImage() != null ? diary.getImage().getUrl() : null;
+        String comment = diary.getComment() != null ? diary.getComment().getContent() : null;
+        return new GetDiaryDetailRes(
+                diary.getDiaryId(),
+                diary.getDate(),
+                diary.getEmotion(),
+                diary.getTitle(),
+                diary.getContent(),
+                imageUrl,
+                comment
+        );
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feat/#25_cal-diary->develop

### 변경 사항
 달력&일기 조회 구현, 그림체 Enum 생성(추후 그림체 확정시 값 변경 예정), Image 엔티티 생성, diary엔티티 참조 수정

### 테스트 결과
- 달력 조회
<img width="400" height="1307" alt="image" src="https://github.com/user-attachments/assets/d763be3b-690f-4331-b64c-31cc5600edbf" />

- 달력 리스트 조회
<img width="400" height="1398" alt="image" src="https://github.com/user-attachments/assets/ab59fc52-91be-460d-a906-2e6cd82c7c33" />

- 일기 미리보기
<img width="400" height="1038" alt="image" src="https://github.com/user-attachments/assets/2fe44a27-0a45-440a-b786-f2eb6c1fc10c" />

- 일기 상세조회
<img width="400" height="1104" alt="image" src="https://github.com/user-attachments/assets/e6271b8b-af9d-495d-8181-3b5b05dc1cc3" />

