### PR TITLE
[FEAT] 대화, 일기, 그림 요청, 재생성 API

### DIFF
--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -5,9 +5,7 @@ import com.example.sketchTalk.dto.chat.in.ChatReq;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.in.PrevDrawReq;
 import com.example.sketchTalk.dto.chat.in.SelectedImageReq;
-import com.example.sketchTalk.dto.chat.out.CompletedDiaryRes;
-import com.example.sketchTalk.dto.chat.out.DrawImageRes;
-import com.example.sketchTalk.dto.chat.out.SecondDrawImageRes;
+import com.example.sketchTalk.dto.chat.out.*;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
@@ -28,14 +26,14 @@ public class ChatController {
     private final ChatService chatService;
 
     @PostMapping("")
-    public ApiResponse<ChatDataBody> chat(@RequestBody ChatReq req, @AuthenticationPrincipal Long userId) {
-        ChatDataBody res = chatService.getReply(req, userId);
+    public ApiResponse<ChatReplyRes> chat(@RequestBody ChatReq req, @AuthenticationPrincipal Long userId) {
+        ChatReplyRes res = chatService.getReply(req, userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 
     @PostMapping("/diary")
-    public ApiResponse<DiaryDataBody> writeDiary(@AuthenticationPrincipal Long userId) {
-        DiaryDataBody res = chatService.getDiary(userId);
+    public ApiResponse<WriteDiaryRes> writeDiary(@AuthenticationPrincipal Long userId) {
+        WriteDiaryRes res = chatService.getDiary(userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 

--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -9,6 +9,7 @@ import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
 import com.example.sketchTalk.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,20 +22,20 @@ public class ChatController {
     private final ChatService chatService;
 
     @PostMapping("")
-    public ApiResponse<ChatDataBody> chat(@RequestBody ChatReq req) {
-        ChatDataBody res = chatService.getReply(req);
+    public ApiResponse<ChatDataBody> chat(@RequestBody ChatReq req, @AuthenticationPrincipal Long userId) {
+        ChatDataBody res = chatService.getReply(req, userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 
     @PostMapping("/diary")
-    public ApiResponse<DiaryDataBody> writeDiary() {
-        DiaryDataBody res = chatService.getDiary();
+    public ApiResponse<DiaryDataBody> writeDiary(@AuthenticationPrincipal Long userId) {
+        DiaryDataBody res = chatService.getDiary(userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 
     @PostMapping("/image")
-    public ApiResponse<ImageDataBody> drawImage(@RequestBody DrawReq req) {
-        ImageDataBody res = chatService.getImage(req);
+    public ApiResponse<ImageDataBody> drawImage(@RequestBody DrawReq req, @AuthenticationPrincipal Long userId) {
+        ImageDataBody res = chatService.getImage(req, userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 }

--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -50,4 +50,9 @@ public class ChatController {
         SecondImageDataBody secondImageRes = chatService.getTwoImages(req.style(), newImageRes, req.prevImageUrl());
         return ApiResponse.onSuccess(HttpStatus.CREATED, secondImageRes);
     }
+
+    /*@PostMapping("/image/save")
+    public ApiResponse<CompletedDiaryRes> completeDiary(@RequestBody SelectedImageReq req) {
+        CompletedDiaryRes res = chatService.getCompletedDiary(req);
+    }*/
 }

--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -6,6 +6,8 @@ import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.in.PrevDrawReq;
 import com.example.sketchTalk.dto.chat.in.SelectedImageReq;
 import com.example.sketchTalk.dto.chat.out.CompletedDiaryRes;
+import com.example.sketchTalk.dto.chat.out.DrawImageRes;
+import com.example.sketchTalk.dto.chat.out.SecondDrawImageRes;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
@@ -38,16 +40,16 @@ public class ChatController {
     }
 
     @PostMapping("/image")
-    public ApiResponse<ImageDataBody> drawImage(@RequestBody DrawReq req, @AuthenticationPrincipal Long userId) {
-        ImageDataBody res = chatService.getImage(req, userId);
+    public ApiResponse<DrawImageRes> drawImage(@RequestBody DrawReq req, @AuthenticationPrincipal Long userId) {
+        DrawImageRes res = chatService.getImage(req, userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 
     @PostMapping("/image/retry")
-    public ApiResponse<SecondImageDataBody> retryDrawImage(@RequestBody PrevDrawReq req, @AuthenticationPrincipal Long userId) {
-        DrawReq drawReq = new DrawReq(req.content(), req.style());
-        ImageDataBody newImageRes = chatService.getImage(drawReq, userId);
-        SecondImageDataBody secondImageRes = chatService.getTwoImages(req.style(), newImageRes, req.prevImageUrl());
+    public ApiResponse<SecondDrawImageRes> retryDrawImage(@RequestBody PrevDrawReq req, @AuthenticationPrincipal Long userId) {
+        DrawReq drawReq = new DrawReq(req.diaryId(), req.content(), req.style());
+        DrawImageRes newImageRes = chatService.getImage(drawReq, userId);
+        SecondDrawImageRes secondImageRes = chatService.getTwoImages(req.diaryId(), req.style(), newImageRes.imageUrl(), req.prevImageUrl());
         return ApiResponse.onSuccess(HttpStatus.CREATED, secondImageRes);
     }
 

--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -4,6 +4,8 @@ import com.example.sketchTalk._core.common.ApiResponse;
 import com.example.sketchTalk.dto.chat.in.ChatReq;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.in.PrevDrawReq;
+import com.example.sketchTalk.dto.chat.in.SelectedImageReq;
+import com.example.sketchTalk.dto.chat.out.CompletedDiaryRes;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
@@ -41,11 +43,11 @@ public class ChatController {
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
     }
 
-    @PostMapping("image/retry")
+    @PostMapping("/image/retry")
     public ApiResponse<SecondImageDataBody> retryDrawImage(@RequestBody PrevDrawReq req, @AuthenticationPrincipal Long userId) {
         DrawReq drawReq = new DrawReq(req.content(), req.style());
         ImageDataBody newImageRes = chatService.getImage(drawReq, userId);
-        SecondImageDataBody secondImageRes = chatService.getTwoImages(newImageRes, req.prevImageUrl());
+        SecondImageDataBody secondImageRes = chatService.getTwoImages(req.style(), newImageRes, req.prevImageUrl());
         return ApiResponse.onSuccess(HttpStatus.CREATED, secondImageRes);
     }
 }

--- a/src/main/java/com/example/sketchTalk/controller/ChatController.java
+++ b/src/main/java/com/example/sketchTalk/controller/ChatController.java
@@ -3,9 +3,11 @@ package com.example.sketchTalk.controller;
 import com.example.sketchTalk._core.common.ApiResponse;
 import com.example.sketchTalk.dto.chat.in.ChatReq;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
+import com.example.sketchTalk.dto.chat.in.PrevDrawReq;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
+import com.example.sketchTalk.dto.webClient.in.SecondImageDataBody;
 import com.example.sketchTalk.service.ChatService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -37,5 +39,13 @@ public class ChatController {
     public ApiResponse<ImageDataBody> drawImage(@RequestBody DrawReq req, @AuthenticationPrincipal Long userId) {
         ImageDataBody res = chatService.getImage(req, userId);
         return ApiResponse.onSuccess(HttpStatus.CREATED, res);
+    }
+
+    @PostMapping("image/retry")
+    public ApiResponse<SecondImageDataBody> retryDrawImage(@RequestBody PrevDrawReq req, @AuthenticationPrincipal Long userId) {
+        DrawReq drawReq = new DrawReq(req.content(), req.style());
+        ImageDataBody newImageRes = chatService.getImage(drawReq, userId);
+        SecondImageDataBody secondImageRes = chatService.getTwoImages(newImageRes, req.prevImageUrl());
+        return ApiResponse.onSuccess(HttpStatus.CREATED, secondImageRes);
     }
 }

--- a/src/main/java/com/example/sketchTalk/controller/DiaryController.java
+++ b/src/main/java/com/example/sketchTalk/controller/DiaryController.java
@@ -52,13 +52,13 @@ public class DiaryController {
 
     @GetMapping("/{id}/preview")
     public ApiResponse<GetDiaryPreviewRes> getDiaryPreview(@PathVariable Long id, @AuthenticationPrincipal Long userId) {
-        GetDiaryPreviewRes getDiaryPreviewRes = diaryService.getDiaryPreviewById(id, userId);
+        GetDiaryPreviewRes getDiaryPreviewRes = diaryService.getDiaryPreviewById(id);
         return ApiResponse.onSuccess(HttpStatus.OK, getDiaryPreviewRes);
     }
 
     @GetMapping("/{id}")
     public ApiResponse<GetDiaryDetailRes> getDiaryDetail(@PathVariable Long id, @AuthenticationPrincipal Long userId) {
-        GetDiaryDetailRes getDiaryDetailRes = diaryService.getDiaryDetailById(id, userId);
+        GetDiaryDetailRes getDiaryDetailRes = diaryService.getDiaryDetailById(id);
         return ApiResponse.onSuccess(HttpStatus.OK, getDiaryDetailRes);
     }
 }

--- a/src/main/java/com/example/sketchTalk/controller/DiaryController.java
+++ b/src/main/java/com/example/sketchTalk/controller/DiaryController.java
@@ -19,8 +19,8 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping("/save")
-    public ApiResponse<SaveDiaryRes> saveDiary(@RequestBody SaveDiaryReq req) {
-        SaveDiaryRes saveDiaryRes = diaryService.putDiary(req);
+    public ApiResponse<SaveDiaryRes> saveDiary(@AuthenticationPrincipal long userId, @RequestBody SaveDiaryReq req) {
+        SaveDiaryRes saveDiaryRes = diaryService.putDiary(userId, req);
         return ApiResponse.onSuccess(HttpStatus.CREATED, saveDiaryRes);
     }
 

--- a/src/main/java/com/example/sketchTalk/controller/DiaryController.java
+++ b/src/main/java/com/example/sketchTalk/controller/DiaryController.java
@@ -19,7 +19,7 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @PostMapping("/save")
-    public ApiResponse<SaveDiaryRes> saveDiary(@AuthenticationPrincipal long userId, @RequestBody SaveDiaryReq req) {
+    public ApiResponse<SaveDiaryRes> saveDiary(@AuthenticationPrincipal Long userId, @RequestBody SaveDiaryReq req) {
         SaveDiaryRes saveDiaryRes = diaryService.putDiary(userId, req);
         return ApiResponse.onSuccess(HttpStatus.CREATED, saveDiaryRes);
     }

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
@@ -1,7 +1,9 @@
 package com.example.sketchTalk.dto.chat.in;
 
+import com.example.sketchTalk.model.Style;
+
 public record DrawReq(
         String content,
-        String style
+        Style style
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
@@ -3,6 +3,7 @@ package com.example.sketchTalk.dto.chat.in;
 import com.example.sketchTalk.model.Style;
 
 public record DrawReq(
+        Long diaryId,
         String content,
         Style style
 ) {

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/DrawReq.java
@@ -1,6 +1,7 @@
 package com.example.sketchTalk.dto.chat.in;
 
 public record DrawReq(
-        String content
+        String content,
+        String style
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/PrevDrawReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/PrevDrawReq.java
@@ -1,8 +1,10 @@
 package com.example.sketchTalk.dto.chat.in;
 
+import com.example.sketchTalk.model.Style;
+
 public record PrevDrawReq(
         String content,
-        String style,
+        Style style,
         String prevImageUrl
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/PrevDrawReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/PrevDrawReq.java
@@ -1,0 +1,8 @@
+package com.example.sketchTalk.dto.chat.in;
+
+public record PrevDrawReq(
+        String content,
+        String style,
+        String prevImageUrl
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/chat/in/SelectedImageReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/in/SelectedImageReq.java
@@ -1,0 +1,10 @@
+package com.example.sketchTalk.dto.chat.in;
+
+import com.example.sketchTalk.model.Style;
+
+public record SelectedImageReq(
+        Long diaryId,
+        Style style,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/chat/out/ChatReplyRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/out/ChatReplyRes.java
@@ -1,0 +1,8 @@
+package com.example.sketchTalk.dto.chat.out;
+
+public record ChatReplyRes(
+        String reply,
+        Boolean isSufficient,
+        String voice
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/chat/out/CompletedDiaryRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/out/CompletedDiaryRes.java
@@ -1,0 +1,20 @@
+package com.example.sketchTalk.dto.chat.out;
+
+import com.example.sketchTalk.model.Emotion;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CompletedDiaryRes(
+        Long diaryId,
+        Instant date,
+        Emotion emotion,
+        String title,
+        String content,
+        String imageURL,
+        String comment,
+        Boolean achieved,
+        List<String> achievedList,
+        String voice
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/chat/out/DrawImageRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/out/DrawImageRes.java
@@ -1,0 +1,10 @@
+package com.example.sketchTalk.dto.chat.out;
+
+import com.example.sketchTalk.model.Style;
+
+public record DrawImageRes(
+        Long diaryId,
+        Style style,
+        String imageUrl
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/chat/out/SecondDrawImageRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/out/SecondDrawImageRes.java
@@ -1,11 +1,11 @@
-package com.example.sketchTalk.dto.chat.in;
+package com.example.sketchTalk.dto.chat.out;
 
 import com.example.sketchTalk.model.Style;
 
-public record PrevDrawReq(
+public record SecondDrawImageRes(
         Long diaryId,
-        String content,
         Style style,
+        String imageURL,
         String prevImageUrl
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/chat/out/WriteDiaryRes.java
+++ b/src/main/java/com/example/sketchTalk/dto/chat/out/WriteDiaryRes.java
@@ -1,0 +1,10 @@
+package com.example.sketchTalk.dto.chat.out;
+
+import com.example.sketchTalk.model.Emotion;
+
+public record WriteDiaryRes(
+        String title,
+        String content,
+        Emotion emotion
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/diary/in/SaveDiaryReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/diary/in/SaveDiaryReq.java
@@ -8,8 +8,6 @@ import java.time.LocalDate;
 public record SaveDiaryReq(
         String title,
         String content,
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-        LocalDate date,
         Emotion emotion
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/diary/in/SaveDiaryReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/diary/in/SaveDiaryReq.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 
 public record SaveDiaryReq(
-        Long userId,//추후에 User로 변경
         String title,
         String content,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")

--- a/src/main/java/com/example/sketchTalk/dto/webClient/in/ImageDataBody.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/in/ImageDataBody.java
@@ -3,8 +3,6 @@ package com.example.sketchTalk.dto.webClient.in;
 import com.example.sketchTalk.model.Style;
 
 public record ImageDataBody(
-        Long diaryId,
-        Style style,
-        String imageURL
+        String image_url
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/webClient/in/ImageDataBody.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/in/ImageDataBody.java
@@ -1,7 +1,10 @@
 package com.example.sketchTalk.dto.webClient.in;
 
+import com.example.sketchTalk.model.Style;
+
 public record ImageDataBody(
         Long diaryId,
+        Style style,
         String imageURL
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/webClient/in/SecondImageDataBody.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/in/SecondImageDataBody.java
@@ -1,0 +1,8 @@
+package com.example.sketchTalk.dto.webClient.in;
+
+public record SecondImageDataBody(
+        Long diaryId,
+        String imageURL,
+        String prevImageUrl
+) {
+}

--- a/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
@@ -1,8 +1,10 @@
 package com.example.sketchTalk.dto.webClient.out;
 
+import com.example.sketchTalk.model.Style;
+
 public record ImageReq(
         Long userId,
         String content,
-        String style
+        Style style
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
@@ -4,7 +4,7 @@ import com.example.sketchTalk.model.Style;
 
 public record ImageReq(
         Long userId,
-        String content,
-        Style style
+        String diary,
+        Style imageStyle
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/out/ImageReq.java
@@ -2,6 +2,7 @@ package com.example.sketchTalk.dto.webClient.out;
 
 public record ImageReq(
         Long userId,
-        String content
+        String content,
+        String style
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/exception/user/UserExceptions.java
+++ b/src/main/java/com/example/sketchTalk/exception/user/UserExceptions.java
@@ -11,7 +11,8 @@ public enum UserExceptions implements BaseErrorCode {
     ID_NOT_FOUND(HttpStatus.UNAUTHORIZED, "U1", "ID를 찾을 수 없습니다."),
     PASSWORD_MISMATCH(HttpStatus.UNAUTHORIZED, "U2", "비밀번호가 일치하지 않습니다."),
     ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "U3", "ID가 이미 존재합니다."),
-    BIRTHDATE_INVALID(HttpStatus.BAD_REQUEST, "U4", "생년월일이 알맞지 않습니다.");
+    BIRTHDATE_INVALID(HttpStatus.BAD_REQUEST, "U4", "생년월일이 알맞지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U5", "해당 사용자가 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/sketchTalk/model/Emotion.java
+++ b/src/main/java/com/example/sketchTalk/model/Emotion.java
@@ -1,5 +1,5 @@
 package com.example.sketchTalk.model;
 
 public enum Emotion {
-    HAPPY, SAD, ANGRY, NEUTRAL
+    HAPPY, SAD, ANGRY, NEUTRAL, EXCITED
 }

--- a/src/main/java/com/example/sketchTalk/model/Emotion.java
+++ b/src/main/java/com/example/sketchTalk/model/Emotion.java
@@ -1,5 +1,5 @@
 package com.example.sketchTalk.model;
 
 public enum Emotion {
-    Happy, Sad, Angry, Neutral
+    HAPPY, SAD, ANGRY, NEUTRAL
 }

--- a/src/main/java/com/example/sketchTalk/model/Style.java
+++ b/src/main/java/com/example/sketchTalk/model/Style.java
@@ -1,5 +1,5 @@
 package com.example.sketchTalk.model;
 
 public enum Style {
-    Temp
+    pastel, childbook, coolkids
 }

--- a/src/main/java/com/example/sketchTalk/model/entity/Diary.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Diary.java
@@ -35,6 +35,7 @@ public class Diary {
     private String content;
 
     @Column(nullable=false)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate date;
 
     @Enumerated(EnumType.STRING)
@@ -53,7 +54,7 @@ public class Diary {
         this.user = user;
         this.title = saveDiaryReq.title();
         this.content = saveDiaryReq.content();
-        this.date = saveDiaryReq.date();
+        this.date = LocalDate.now();
         this.emotion = saveDiaryReq.emotion();
         this.createdAt = LocalDateTime.now();
     }

--- a/src/main/java/com/example/sketchTalk/model/entity/Diary.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Diary.java
@@ -24,10 +24,9 @@ public class Diary {
     @Column(name="diary_id")
     private Long diaryId;
 
-    //@ManyToOne <- 추후에 User로 변경
-    //@JoinColumn(name="user_id")
-    @Column(name="user_id")
-    private Long userId;
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user;
 
     @Column(nullable=false)
     private String title;
@@ -50,8 +49,8 @@ public class Diary {
     @OneToOne(mappedBy = "diary", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = true)
     private Comment comment;
 
-    public Diary(SaveDiaryReq saveDiaryReq) {
-        this.userId = saveDiaryReq.userId();//추후에 User로 변경
+    public Diary(User user, SaveDiaryReq saveDiaryReq) {
+        this.user = user;
         this.title = saveDiaryReq.title();
         this.content = saveDiaryReq.content();
         this.date = saveDiaryReq.date();

--- a/src/main/java/com/example/sketchTalk/model/entity/Diary.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Diary.java
@@ -65,5 +65,9 @@ public class Diary {
         this.updatedAt = LocalDateTime.now();
     }
 
+    public void saveImage(Image image) {
+        this.image = image;
+    }
+
 
 }

--- a/src/main/java/com/example/sketchTalk/model/entity/Image.java
+++ b/src/main/java/com/example/sketchTalk/model/entity/Image.java
@@ -26,4 +26,10 @@ public class Image {
 
     @Column(nullable = false)
     private String url;
+
+    public Image(Diary diary, Style style, String url) {
+        this.diary = diary;
+        this.style = style;
+        this.url = url;
+    }
 }

--- a/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
+++ b/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
@@ -6,13 +6,12 @@ import com.example.sketchTalk.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    List<GetCalanderDiraryRes> findAllByUserIdAndDateBetween(User user, LocalDate dateAfter, LocalDate dateBefore);
-    List<Diary> findAllByUserIdAndDateBetweenOrderByDateAsc(User user, LocalDate start, LocalDate end);
+    List<GetCalanderDiraryRes> findAllByUserAndDateBetween(User user, LocalDate dateAfter, LocalDate dateBefore);
+    List<Diary> findAllByUserAndDateBetweenOrderByDateAsc(User user, LocalDate start, LocalDate end);
 
-    Optional<Diary> findByUserIdAndDiaryId(User user, Long diaryId);
+    Optional<Diary> findByDiaryId(Long diaryId);
 }

--- a/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
+++ b/src/main/java/com/example/sketchTalk/repository/DiaryRepository.java
@@ -2,6 +2,7 @@ package com.example.sketchTalk.repository;
 
 import com.example.sketchTalk.dto.diary.out.GetCalanderDiraryRes;
 import com.example.sketchTalk.model.entity.Diary;
+import com.example.sketchTalk.model.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -10,8 +11,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    List<GetCalanderDiraryRes> findAllByUserIdAndDateBetween(Long userId, LocalDate dateAfter, LocalDate dateBefore);
-    List<Diary> findAllByUserIdAndDateBetweenOrderByDateAsc(Long userId, LocalDate start, LocalDate end);
+    List<GetCalanderDiraryRes> findAllByUserIdAndDateBetween(User user, LocalDate dateAfter, LocalDate dateBefore);
+    List<Diary> findAllByUserIdAndDateBetweenOrderByDateAsc(User user, LocalDate start, LocalDate end);
 
-    Optional<Diary> findByUserIdAndDiaryId(Long userId, Long diaryId);
+    Optional<Diary> findByUserIdAndDiaryId(User user, Long diaryId);
 }

--- a/src/main/java/com/example/sketchTalk/repository/ImageRepository.java
+++ b/src/main/java/com/example/sketchTalk/repository/ImageRepository.java
@@ -1,0 +1,7 @@
+package com.example.sketchTalk.repository;
+
+import com.example.sketchTalk.model.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/com/example/sketchTalk/service/AIRequestService.java
+++ b/src/main/java/com/example/sketchTalk/service/AIRequestService.java
@@ -20,6 +20,8 @@ public class AIRequestService {
     private final WebClient webClient;
     @Value("${fastapi.endpoint}")
     private String baseURL;
+    @Value("${fastapi.image-endpoint}")
+    private String imageURL;
 
     public ReplyRes sendChat(Long userId, String dialog) {
         String uri = baseURL + "/chat";
@@ -43,7 +45,7 @@ public class AIRequestService {
     public DiaryRes requestDiary(Long userId) {
         String uri = baseURL + "/diary";
         DiaryReq diaryReq = new DiaryReq(userId);
-        Mono<DiaryRes> result = webClient.post()//현재 명세서에는 GET으로 되어있음 -> 변경 요청
+        Mono<DiaryRes> result = webClient.post()
                 .uri(uri)
                 .bodyValue(diaryReq)
                 .retrieve()
@@ -59,9 +61,10 @@ public class AIRequestService {
     }
 
     public ImageRes requestImage(Long userId, DrawReq req) {
-        String uri = baseURL + "/image";
+        String uri = imageURL + "/image";
+        System.out.println("uri : "+uri);
         ImageReq imageReq = new ImageReq(userId, req.content(), req.style());
-        Mono<ImageRes> result = webClient.post()//현재 명세서에는 GET으로 되어있음 -> 변경 요청
+        Mono<ImageRes> result = webClient.post()
                 .uri(uri)
                 .bodyValue(imageReq)
                 .retrieve()

--- a/src/main/java/com/example/sketchTalk/service/AIRequestService.java
+++ b/src/main/java/com/example/sketchTalk/service/AIRequestService.java
@@ -1,5 +1,6 @@
 package com.example.sketchTalk.service;
 
+import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.out.ImageRes;
 import com.example.sketchTalk.dto.webClient.out.DiaryReq;
 import com.example.sketchTalk.dto.webClient.out.ImageReq;
@@ -20,7 +21,7 @@ public class AIRequestService {
     @Value("${fastapi.endpoint}")
     private String baseURL;
 
-    public ReplyRes sendChat(long userId, String dialog) {
+    public ReplyRes sendChat(Long userId, String dialog) {
         String uri = baseURL + "/chat";
         ReplyReq replyReq = new ReplyReq(userId, dialog);
         Mono<ReplyRes> result = webClient.post()
@@ -39,7 +40,7 @@ public class AIRequestService {
         return result.block();
     }
 
-    public DiaryRes requestDiary(long userId) {
+    public DiaryRes requestDiary(Long userId) {
         String uri = baseURL + "/diary";
         DiaryReq diaryReq = new DiaryReq(userId);
         Mono<DiaryRes> result = webClient.post()//현재 명세서에는 GET으로 되어있음 -> 변경 요청
@@ -57,9 +58,9 @@ public class AIRequestService {
         return result.block();
     }
 
-    public ImageRes requestImage(long userId, String content) {
+    public ImageRes requestImage(Long userId, DrawReq req) {
         String uri = baseURL + "/image";
-        ImageReq imageReq = new ImageReq(userId, content);
+        ImageReq imageReq = new ImageReq(userId, req.content(), req.style());
         Mono<ImageRes> result = webClient.post()//현재 명세서에는 GET으로 되어있음 -> 변경 요청
                 .uri(uri)
                 .bodyValue(imageReq)

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -19,24 +19,21 @@ public class ChatService {
 
     private final AIRequestService aiRequestService;
 
-    public ChatDataBody getReply(ChatReq chatReq) {
-        long userId = 1L;
+    public ChatDataBody getReply(ChatReq chatReq, Long userId) {
         System.out.println("text : " + chatReq.dialog());
         ReplyRes replyRes = aiRequestService.sendChat(userId, chatReq.dialog());
         if(replyRes.isSuccess()) return replyRes.data();
         else throw new CustomException(ChatExceptions.SEND_CHAT_ERROR);
     }
 
-    public DiaryDataBody getDiary() {
-        long userId = 1L;
+    public DiaryDataBody getDiary(Long userId) {
         DiaryRes diaryRes = aiRequestService.requestDiary(userId);
         if(diaryRes.isSuccess()) return diaryRes.data();
         else throw new CustomException(ChatExceptions.WRITE_DIARY_ERROR);
     }
 
-    public ImageDataBody getImage(DrawReq req) {
-        long userId = 1L;
-        ImageRes imageRes = aiRequestService.requestImage(userId, req.content());
+    public ImageDataBody getImage(DrawReq req, Long userId) {
+        ImageRes imageRes = aiRequestService.requestImage(userId, req);
         if(imageRes.isSuccess()) return imageRes.data();
         else throw new CustomException(ChatExceptions.DRAW_IMAGE_ERROR);
     }

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -11,6 +11,11 @@ import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
 import com.example.sketchTalk.dto.webClient.in.SecondImageDataBody;
 import com.example.sketchTalk.exception.chat.ChatExceptions;
+import com.example.sketchTalk.exception.diary.DiaryExceptions;
+import com.example.sketchTalk.model.Style;
+import com.example.sketchTalk.model.entity.Diary;
+import com.example.sketchTalk.model.entity.Image;
+import com.example.sketchTalk.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -35,11 +40,11 @@ public class ChatService {
 
     public ImageDataBody getImage(DrawReq req, Long userId) {
         ImageRes imageRes = aiRequestService.requestImage(userId, req);
-        if(imageRes.isSuccess()) return imageRes.data();
+        if(imageRes.isSuccess()) return new ImageDataBody(imageRes.data().diaryId(), req.style(), imageRes.data().imageURL());
         else throw new CustomException(ChatExceptions.DRAW_IMAGE_ERROR);
     }
 
-    public SecondImageDataBody getTwoImages(ImageDataBody imageDataBody, String prevImageUrl) {
+    public SecondImageDataBody getTwoImages(Style style, ImageDataBody imageDataBody, String prevImageUrl) {
         return new SecondImageDataBody(imageDataBody.diaryId(), imageDataBody.imageURL(), prevImageUrl);
     }
 }

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -4,10 +4,7 @@ import com.example.sketchTalk._core.error.CustomException;
 import com.example.sketchTalk.dto.chat.in.ChatReq;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.in.SelectedImageReq;
-import com.example.sketchTalk.dto.chat.out.CompletedDiaryRes;
-import com.example.sketchTalk.dto.chat.out.DiaryRes;
-import com.example.sketchTalk.dto.chat.out.ImageRes;
-import com.example.sketchTalk.dto.chat.out.ReplyRes;
+import com.example.sketchTalk.dto.chat.out.*;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
@@ -44,14 +41,14 @@ public class ChatService {
         else throw new CustomException(ChatExceptions.WRITE_DIARY_ERROR);
     }
 
-    public ImageDataBody getImage(DrawReq req, Long userId) {
+    public DrawImageRes getImage(DrawReq req, Long userId) {
         ImageRes imageRes = aiRequestService.requestImage(userId, req);
-        if(imageRes.isSuccess()) return new ImageDataBody(imageRes.data().diaryId(), req.style(), imageRes.data().imageURL());
+        if(imageRes.isSuccess()) return new DrawImageRes(req.diaryId(), req.style(), imageRes.data().image_url());
         else throw new CustomException(ChatExceptions.DRAW_IMAGE_ERROR);
     }
 
-    public SecondImageDataBody getTwoImages(Style style, ImageDataBody imageDataBody, String prevImageUrl) {
-        return new SecondImageDataBody(imageDataBody.diaryId(), imageDataBody.imageURL(), prevImageUrl);
+    public SecondDrawImageRes getTwoImages(Long diaryId, Style style, String newImageURL, String prevImageUrl) {
+        return new SecondDrawImageRes(diaryId, style, newImageURL, prevImageUrl);
     }
 
     /*@Transactional

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -3,6 +3,8 @@ package com.example.sketchTalk.service;
 import com.example.sketchTalk._core.error.CustomException;
 import com.example.sketchTalk.dto.chat.in.ChatReq;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
+import com.example.sketchTalk.dto.chat.in.SelectedImageReq;
+import com.example.sketchTalk.dto.chat.out.CompletedDiaryRes;
 import com.example.sketchTalk.dto.chat.out.DiaryRes;
 import com.example.sketchTalk.dto.chat.out.ImageRes;
 import com.example.sketchTalk.dto.chat.out.ReplyRes;
@@ -16,6 +18,8 @@ import com.example.sketchTalk.model.Style;
 import com.example.sketchTalk.model.entity.Diary;
 import com.example.sketchTalk.model.entity.Image;
 import com.example.sketchTalk.repository.DiaryRepository;
+import com.example.sketchTalk.repository.ImageRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,6 +28,8 @@ import org.springframework.stereotype.Service;
 public class ChatService {
 
     private final AIRequestService aiRequestService;
+    private final DiaryRepository diaryRepository;
+    private final ImageRepository imageRepository;
 
     public ChatDataBody getReply(ChatReq chatReq, Long userId) {
         System.out.println("text : " + chatReq.dialog());
@@ -47,4 +53,17 @@ public class ChatService {
     public SecondImageDataBody getTwoImages(Style style, ImageDataBody imageDataBody, String prevImageUrl) {
         return new SecondImageDataBody(imageDataBody.diaryId(), imageDataBody.imageURL(), prevImageUrl);
     }
+
+    /*@Transactional
+    public CompletedDiaryRes getCompletedDiary(SelectedImageReq req) {
+        //일기 저장
+        Diary diary = diaryRepository.findByDiaryId(req.diaryId()).orElseThrow(()->new CustomException(DiaryExceptions.DIARY_NOT_FOUND, req.diaryId()));
+        Image image = new Image(diary, req.style(), req.imageUrl());
+        diary.saveImage(image);
+        imageRepository.save(image);
+        //코멘트 요청(병렬)
+
+        //도전과제 검색(병렬)
+        //응답 생성 및 반환
+    }*/
 }

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -9,6 +9,7 @@ import com.example.sketchTalk.dto.chat.out.ReplyRes;
 import com.example.sketchTalk.dto.webClient.in.ChatDataBody;
 import com.example.sketchTalk.dto.webClient.in.DiaryDataBody;
 import com.example.sketchTalk.dto.webClient.in.ImageDataBody;
+import com.example.sketchTalk.dto.webClient.in.SecondImageDataBody;
 import com.example.sketchTalk.exception.chat.ChatExceptions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,5 +37,9 @@ public class ChatService {
         ImageRes imageRes = aiRequestService.requestImage(userId, req);
         if(imageRes.isSuccess()) return imageRes.data();
         else throw new CustomException(ChatExceptions.DRAW_IMAGE_ERROR);
+    }
+
+    public SecondImageDataBody getTwoImages(ImageDataBody imageDataBody, String prevImageUrl) {
+        return new SecondImageDataBody(imageDataBody.diaryId(), imageDataBody.imageURL(), prevImageUrl);
     }
 }

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -28,16 +28,18 @@ public class ChatService {
     private final DiaryRepository diaryRepository;
     private final ImageRepository imageRepository;
 
-    public ChatDataBody getReply(ChatReq chatReq, Long userId) {
+    public ChatReplyRes getReply(ChatReq chatReq, Long userId) {
         System.out.println("text : " + chatReq.dialog());
         ReplyRes replyRes = aiRequestService.sendChat(userId, chatReq.dialog());
-        if(replyRes.isSuccess()) return replyRes.data();
+        if(replyRes.isSuccess()) {
+            return new ChatReplyRes(replyRes.data().reply(), replyRes.data().isSufficient(), "boy");//voice 조회 로직 추가예정
+        }
         else throw new CustomException(ChatExceptions.SEND_CHAT_ERROR);
     }
 
-    public DiaryDataBody getDiary(Long userId) {
+    public WriteDiaryRes getDiary(Long userId) {
         DiaryRes diaryRes = aiRequestService.requestDiary(userId);
-        if(diaryRes.isSuccess()) return diaryRes.data();
+        if(diaryRes.isSuccess()) return new WriteDiaryRes(diaryRes.data().title(), diaryRes.data().content(), diaryRes.data().emotion());
         else throw new CustomException(ChatExceptions.WRITE_DIARY_ERROR);
     }
 

--- a/src/main/java/com/example/sketchTalk/service/DiaryService.java
+++ b/src/main/java/com/example/sketchTalk/service/DiaryService.java
@@ -4,9 +4,6 @@ import com.example.sketchTalk._core.error.CustomException;
 
 import com.example.sketchTalk.dto.category.out.AchievedResultRes;
 import com.example.sketchTalk.dto.category.out.CategoryCompletionRes;
-import com.example.sketchTalk.dto.comment.in.SaveCommentReq;
-import com.example.sketchTalk.dto.comment.out.ReqContentRes;
-import com.example.sketchTalk.dto.comment.out.SaveCommentRes;
 import com.example.sketchTalk.dto.diary.in.ModifyDiaryReq;
 import com.example.sketchTalk.dto.diary.in.SaveDiaryReq;
 import com.example.sketchTalk.dto.diary.out.*;
@@ -14,8 +11,9 @@ import com.example.sketchTalk.dto.diary.out.SaveDiaryRes;
 import com.example.sketchTalk.dto.subcategory.out.SubCategoryNamesDTO;
 import com.example.sketchTalk.exception.diary.DiaryExceptions;
 import com.example.sketchTalk.model.entity.Diary;
+import com.example.sketchTalk.model.entity.User;
 import com.example.sketchTalk.repository.DiaryRepository;
-import com.example.sketchTalk.repository.achievement.SubCategoryRepository;
+import com.example.sketchTalk.repository.UserRepository;
 import com.example.sketchTalk.security.jwt.JwtUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -33,10 +31,12 @@ public class DiaryService {
     private final SubCategoryService subCategoryService;
     private final CategoryService categoryService;
     private final JwtUtils jwtUtils;
+    private final UserRepository userRepository;
 //    private final CommentService commentService;
 
-    public SaveDiaryRes putDiary(SaveDiaryReq saveDiaryReq) {
-        Diary diary = new Diary(saveDiaryReq);
+    public SaveDiaryRes putDiary(long userId, SaveDiaryReq saveDiaryReq) {
+        User user = userRepository.findById(userId).orElse(null);
+        Diary diary = new Diary(user, saveDiaryReq);
         Diary savedDiary = diaryRepository.save(diary);
 
 //        ReqContentRes writtenComment = commentService.reqComment(diary.getContent());
@@ -91,15 +91,17 @@ public class DiaryService {
     public List<GetCalanderDiraryRes> getCalanderByMonth(int year, int month, Long userId) {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        User user = userRepository.findById(userId).orElse(null);
 
-        return diaryRepository.findAllByUserIdAndDateBetween(userId, start, end);
+        return diaryRepository.findAllByUserAndDateBetween(user, start, end);
     }
 
     public List<GetDiaryPreviewRes> getDiaryListByMonth(int year, int month, Long userId) {
         LocalDate start = LocalDate.of(year, month, 1);
         LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+        User user = userRepository.findById(userId).orElse(null);
 
-        return diaryRepository.findAllByUserIdAndDateBetweenOrderByDateAsc(userId, start, end)
+        return diaryRepository.findAllByUserAndDateBetweenOrderByDateAsc(user, start, end)
                 .stream()
                 .map(d -> {
                     String imageUrl = d.getImage() != null ? d.getImage().getUrl() : null;
@@ -114,8 +116,8 @@ public class DiaryService {
                 .toList();
     }
 
-    public GetDiaryPreviewRes getDiaryPreviewById(Long id, Long userId) {
-        Diary diary = diaryRepository.findByUserIdAndDiaryId(userId, id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
+    public GetDiaryPreviewRes getDiaryPreviewById(Long id) {
+        Diary diary = diaryRepository.findByDiaryId(id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
 
         String imageUrl = diary.getImage() != null ? diary.getImage().getUrl() : null;
         return new GetDiaryPreviewRes(
@@ -127,8 +129,8 @@ public class DiaryService {
         );
     }
 
-    public GetDiaryDetailRes getDiaryDetailById(Long id, Long userId) {
-        Diary diary = diaryRepository.findByUserIdAndDiaryId(userId, id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
+    public GetDiaryDetailRes getDiaryDetailById(Long id) {
+        Diary diary = diaryRepository.findByDiaryId(id).orElseThrow(() -> new CustomException(DiaryExceptions.DIARY_NOT_FOUND, id));
 
         String imageUrl = diary.getImage() != null ? diary.getImage().getUrl() : null;
         String comment = diary.getComment() != null ? diary.getComment().getContent() : null;

--- a/src/main/java/com/example/sketchTalk/service/DiaryService.java
+++ b/src/main/java/com/example/sketchTalk/service/DiaryService.java
@@ -57,7 +57,9 @@ public class DiaryService {
                 .diaryId(diary.getDiaryId())
                 .date(diary.getDate())
                 .title(diary.getTitle())
-                .emotion(diary.getEmotion())
+                .emotion(diary.getEmotion(
+
+                ))
                 .content(diary.getContent())
                 .build();
         return modifyDiaryRes;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,8 @@ spring:
       maxRequestSize: 300MB
 
 fastapi:
-  endpoint: http://43.201.10.241
+  endpoint: http://13.125.170.8
+  image-endpoint : http://16.184.59.146:8000
   
 cloud:
   aws:


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> main
feat/#29_chat -> develop

### 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
대화, 일기, 그림 요청, 재생성 기능을 추가했습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

채팅
<img width="1101" height="658" alt="image" src="https://github.com/user-attachments/assets/b9ce84b4-dacf-4725-a3a0-23f2b12ea91e" />

일기 생성
<img width="1289" height="725" alt="image" src="https://github.com/user-attachments/assets/35204ffd-a176-401f-9815-005d3ce0f034" />

일기 저장
<img width="1325" height="759" alt="image" src="https://github.com/user-attachments/assets/ef154090-1788-440c-bc08-39bfa733ed06" />

그림 생성
<img width="1276" height="693" alt="image" src="https://github.com/user-attachments/assets/5e9ce88f-625f-485e-a015-5968c3041b25" />

그림 재생성
<img width="1321" height="706" alt="image" src="https://github.com/user-attachments/assets/3223a985-5cfb-402a-8b3c-cde9f8a0e565" />
