### PR TITLE
[FIX] 아이디 중복조회 GET + RequestBody 오류 수정

### DIFF
--- a/src/main/java/com/example/sketchTalk/controller/UserController.java
+++ b/src/main/java/com/example/sketchTalk/controller/UserController.java
@@ -38,6 +38,7 @@ public class UserController {
         return ApiResponse.onSuccess(HttpStatus.OK, result);
     }
 
+    // 수정
     @GetMapping("/id/availability")
     public ApiResponse<CheckDuplicateIdRes> checkDuplicateId(@RequestParam String loginId) {
         CheckDuplicateIdRes result = service.checkDuplicateId(loginId);


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
temp/trigger -> develop

### 변경 사항
- 아이디 중복조회를 GET + RequestBody -> GET + RequestParam으로 바꿨습니다.
- 관련 DTO를 삭제하고, 관련 서비스 메소드의 파라미터를 loginId로 교체했습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.