### PR TITLE
[REFACTOR] 유저 정보 수정 API 변경

### DIFF
--- a/src/main/java/com/example/sketchTalk/controller/UserController.java
+++ b/src/main/java/com/example/sketchTalk/controller/UserController.java
@@ -64,8 +64,11 @@ public class UserController {
     }
 
     @PutMapping
-    public ApiResponse<UpdateUserInfoRes> updateUserInformation(@RequestBody UpdateUserInfoReq updateUserInfoReq) {
-        UpdateUserInfoRes result = service.updateUserInformation(updateUserInfoReq);
+    public ApiResponse<UpdateUserInfoRes> updateUserInformation(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody UpdateUserInfoReq updateUserInfoReq
+    ) {
+        UpdateUserInfoRes result = service.updateUserInformation(userId, updateUserInfoReq);
 
         return ApiResponse.onSuccess(HttpStatus.OK, result);
     }

--- a/src/main/java/com/example/sketchTalk/dto/user/in/UpdateUserInfoReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/user/in/UpdateUserInfoReq.java
@@ -8,7 +8,6 @@ public record UpdateUserInfoReq(
         String nickname,
         @JsonFormat(shape = JsonFormat.Shape.STRING,pattern = "yyyy-MM-dd")
         LocalDate birthdate,
-        String loginId,
         String password
 ) {
 }

--- a/src/main/java/com/example/sketchTalk/service/UserService.java
+++ b/src/main/java/com/example/sketchTalk/service/UserService.java
@@ -98,8 +98,8 @@ public class UserService {
     }
 
     @Transactional
-    public UpdateUserInfoRes updateUserInformation(UpdateUserInfoReq req) {
-        User user = userRepository.findByLoginId(req.loginId())
+    public UpdateUserInfoRes updateUserInformation(Long userId, UpdateUserInfoReq req) {
+        User user = userRepository.findByUserId(userId)
                 .orElseThrow( () -> new CustomException(UserExceptions.ID_NOT_FOUND));
 
         user.updatePassword(passwordEncoder.encode(req.password()));


### PR DESCRIPTION
- 유저 정보 수정에 loginId를 넣지 않도록 변경했습니다.

### PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> main

### 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.