### PR TITLE
[FEAT] 영어 번역 API 연동

### DIFF
--- a/src/main/java/com/example/sketchTalk/dto/webClient/out/EnglishReq.java
+++ b/src/main/java/com/example/sketchTalk/dto/webClient/out/EnglishReq.java
@@ -1,0 +1,7 @@
+package com.example.sketchTalk.dto.webClient.out;
+
+public record EnglishReq(
+        Long userId,
+        String diary
+) {
+}

--- a/src/main/java/com/example/sketchTalk/service/AIRequestService.java
+++ b/src/main/java/com/example/sketchTalk/service/AIRequestService.java
@@ -3,10 +3,7 @@ package com.example.sketchTalk.service;
 import com.example.sketchTalk.dto.chat.in.DrawReq;
 import com.example.sketchTalk.dto.chat.out.CommentRes;
 import com.example.sketchTalk.dto.chat.out.ImageRes;
-import com.example.sketchTalk.dto.webClient.out.CommentReq;
-import com.example.sketchTalk.dto.webClient.out.DiaryReq;
-import com.example.sketchTalk.dto.webClient.out.ImageReq;
-import com.example.sketchTalk.dto.webClient.out.ReplyReq;
+import com.example.sketchTalk.dto.webClient.out.*;
 import com.example.sketchTalk.dto.chat.out.DiaryRes;
 import com.example.sketchTalk.dto.chat.out.ReplyRes;
 import lombok.RequiredArgsConstructor;
@@ -60,6 +57,33 @@ public class AIRequestService {
                 })
                 .bodyToMono(DiaryRes.class);
         return result.block();
+    }
+
+    public DrawReq requestEnglish(Long userId, String koreanText, DrawReq drawReq) {
+        String uri = baseURL + "/diary/english";
+        System.out.println("uri : "+uri);
+        EnglishReq englishReq = new EnglishReq(userId, koreanText);
+        Mono<String> result = webClient.post()
+                .uri(uri)
+                .bodyValue(englishReq)
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(), response -> {
+                    return response.bodyToMono(String.class)
+                            .flatMap(body -> {
+                                System.err.println("FastAPI 422 Error Body: " + body);
+                                return Mono.error(new RuntimeException("FastAPI 요청 실패: " + response.statusCode() + " - " + body));
+                            });
+                })
+                .bodyToMono(String.class);
+        String englishResult;
+        try {
+            englishResult = result.block();
+        } catch (Exception e) {
+            // 통신 또는 처리 중 에러 발생 시 적절한 예외 처리
+            System.err.println("AI 서버 통신 중 치명적인 오류 발생: " + e.getMessage());
+            throw new RuntimeException("AI 콘텐츠 생성 실패", e);
+        }
+        return new DrawReq(drawReq.diaryId(), englishResult, drawReq.style());
     }
 
     public ImageRes requestImage(Long userId, DrawReq req) {

--- a/src/main/java/com/example/sketchTalk/service/ChatService.java
+++ b/src/main/java/com/example/sketchTalk/service/ChatService.java
@@ -56,11 +56,22 @@ public class ChatService {
     }
 
     public DrawImageRes getImage(DrawReq req, Long userId) {
-        ImageRes imageRes = aiRequestService.requestImage(userId, req);
+        //줄바꿈 제거
+        String requestContent = removeLine(req.content());
+        //번역
+        DrawReq englishDrawReq = aiRequestService.requestEnglish(userId, requestContent, req);
+        System.out.println("englishText : " + englishDrawReq.content());
+        ImageRes imageRes = aiRequestService.requestImage(userId, englishDrawReq);
         if(imageRes.isSuccess()) return new DrawImageRes(req.diaryId(), req.style(), imageRes.data().image_url());
         else throw new CustomException(ChatExceptions.DRAW_IMAGE_ERROR);
     }
 
+    private String removeLine(String text) {
+        if (text == null) {
+            return null;
+        }
+        return text.replaceAll("\n", "");
+    }
     public SecondDrawImageRes getTwoImages(Long diaryId, Style style, String newImageURL, String prevImageUrl) {
         return new SecondDrawImageRes(diaryId, style, newImageURL, prevImageUrl);
     }


### PR DESCRIPTION
#48

### PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/login -> main
feat/#48_english -> develop

### 변경 사항
ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
일기 -> 영어 번역 API 연동

### 테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
<img width="1173" height="63" alt="image" src="https://github.com/user-attachments/assets/923ec570-8817-4add-8dec-92cec59fd051" />
